### PR TITLE
Harden MCP server for stdio transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A fully local Retrieval Augmented Generation (RAG) system that gives [LM Studio]
 - 🐳 **One-click setup** - Containerized with Docker for easy deployment
 - 🔧 **Cross-platform** - Works on Windows, Mac, and Linux
 - 🖥️ **GUI prototype** - Electron-based interface to tweak settings and control services
+- 🧩 **Robust MCP server** - Uses stdio transport and logs to stderr for reliable JSON-RPC communication
 
 
 ## 🚀 Quick Start


### PR DESCRIPTION
## Summary
- route all debug output to stderr to keep MCP stdout clean
- run MCP server via stdio transport and handle clean shutdown errors
- document stdio transport in README

## Testing
- `python -m py_compile orchestrator/server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a38af11e248326997a5012b9b29496