### PR TITLE
Add tests for query parsing and chunking

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,18 @@
+name: Python tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install pytest
+      - name: Run tests
+        run: pytest

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,70 @@
+import sys
+import types
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Stub external dependencies to avoid import errors during testing
+
+# Helper to create simple module with attributes
+def stub_module(name, attrs):
+    module = types.ModuleType(name)
+    for attr_name, attr_value in attrs.items():
+        setattr(module, attr_name, attr_value)
+    sys.modules[name] = module
+    return module
+
+# qdrant_client stubs
+if 'qdrant_client' not in sys.modules:
+    stub_module('qdrant_client', {'QdrantClient': object})
+    qm = types.SimpleNamespace(
+        VectorParams=object,
+        Distance=types.SimpleNamespace(COSINE=object),
+        OptimizersConfigDiff=object,
+    )
+    stub_module('qdrant_client.http', {'models': qm})
+    sys.modules['qdrant_client.http.models'] = qm
+
+# FlagEmbedding stub
+if 'FlagEmbedding' not in sys.modules:
+    stub_module('FlagEmbedding', {'BGEM3FlagModel': object})
+
+# bs4 stub
+if 'bs4' not in sys.modules:
+    stub_module('bs4', {'BeautifulSoup': object})
+
+# mcp stubs
+if 'mcp' not in sys.modules:
+    class DummyServer:
+        def __init__(self, *a, **k):
+            pass
+        def call_tool(self):
+            def decorator(f):
+                return f
+            return decorator
+        def list_tools(self):
+            def decorator(f):
+                return f
+            return decorator
+        def run(self, *a, **k):
+            pass
+    async def _async_ctx():
+        class _Ctx:
+            async def __aenter__(self):
+                return None, None
+            async def __aexit__(self, exc_type, exc, tb):
+                pass
+        return _Ctx()
+    server_mod = stub_module('mcp.server', {'Server': DummyServer})
+    transport_stdio_mod = stub_module('mcp.transport.stdio', {'stdio_transport': lambda: _async_ctx()})
+    transport_mod = stub_module('mcp.transport', {'stdio': transport_stdio_mod})
+    types_mod = stub_module('mcp.types', {'Tool': object, 'TextContent': object})
+    mcp_mod = stub_module('mcp', {'server': server_mod, 'transport': transport_mod, 'types': types_mod})
+
+# aiohttp and httpx stubs if missing
+if 'aiohttp' not in sys.modules:
+    stub_module('aiohttp', {'ClientSession': object, 'ClientError': Exception})
+if 'httpx' not in sys.modules:
+    stub_module('httpx', {'AsyncClient': object})

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,47 @@
+import json
+
+import pytest
+
+from orchestrator.server import parse_queries_from_prompt, simple_queries, chunk_text
+
+
+def test_parse_queries_from_prompt_json(monkeypatch):
+    monkeypatch.setattr('orchestrator.server.N_QUERIES', 2, raising=False)
+    prompt = json.dumps({'queries': ['q1', 'q2', 'q3'], 'claim': 'some claim'})
+    queries, claim = parse_queries_from_prompt(prompt)
+    assert queries == ['q1', 'q2']
+    assert claim == 'some claim'
+
+
+def test_parse_queries_from_prompt_structured(monkeypatch):
+    monkeypatch.setattr('orchestrator.server.N_QUERIES', 5, raising=False)
+    prompt = (
+        "QUERIES:\n"
+        "1. first query\n"
+        "- second query\n"
+        "CLAIM:\n"
+        "This is the claim"
+    )
+    queries, claim = parse_queries_from_prompt(prompt)
+    assert queries == ['first query', 'second query']
+    assert claim == 'This is the claim'
+
+
+def test_simple_queries_generation():
+    prompt = 'CLAIM TO EVALUATE: "The Moon is made of cheese and is delicious"'
+    result = simple_queries(prompt, 3)
+    assert result == ['moon made cheese delicious'] * 3
+
+
+def test_chunk_text_short_text():
+    assert chunk_text('short text') == []
+
+
+def test_chunk_text_overlap_logic():
+    text = 'x' * 2500
+    chunks = chunk_text(text, size=1000, overlap=100)
+    assert len(chunks) == 3
+    assert chunks[0][1:] == (0, 1000)
+    assert chunks[1][1:] == (900, 1900)
+    assert chunks[2][1:] == (1800, 2500)
+    assert [len(seg) for seg, _, _ in chunks] == [1000, 1000, 700]


### PR DESCRIPTION
## Summary
- add pytest workflow to run tests
- test query parsing for JSON and structured prompts
- test simple query fallback and text chunking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3a7e4f7e083269576d6539ed843f4