### PR TITLE
Add robust argument normalizer for search tool

### DIFF
--- a/orchestrator/test_normalize_args.py
+++ b/orchestrator/test_normalize_args.py
@@ -1,0 +1,49 @@
+import pytest
+from orchestrator.server import normalize_args, MAX_QUERIES
+
+
+def test_direct_queries():
+    args = {"queries": ["ant", "bee"], "claim": "c"}
+    out = normalize_args(args)
+    assert out["queries"] == ["ant", "bee"]
+    assert out["claim"] == "c"
+
+
+def test_nested_json_string():
+    args = {"prompt": '{"queries":["a","b"],"claim":"x"}'}
+    out = normalize_args(args)
+    assert out == {"queries": ["a", "b"], "claim": "x"}
+
+
+def test_code_fenced_json():
+    args = {"prompt": "```json\n{\"queries\":[\"a\",\"b\"]}\n```"}
+    out = normalize_args(args)
+    assert out["queries"] == ["a", "b"]
+
+
+def test_bullet_list():
+    text = "QUERIES:\n- a\n- b\nCLAIM: c"
+    out = normalize_args({"prompt": text})
+    assert out == {"queries": ["a", "b"], "claim": "c"}
+
+
+def test_newline_list():
+    text = "alpha\nbeta"
+    out = normalize_args({"prompt": text})
+    assert out["queries"] == ["alpha", "beta"]
+
+
+def test_single_query_alias():
+    out = normalize_args({"query": "a"})
+    assert out["queries"] == ["a"]
+
+
+def test_query_cap():
+    many = {"queries": [f"q{i}" for i in range(MAX_QUERIES + 5)]}
+    out = normalize_args(many)
+    assert len(out["queries"]) == MAX_QUERIES
+
+
+def test_empty_error():
+    with pytest.raises(ValueError):
+        normalize_args({})


### PR DESCRIPTION
## Summary
- Normalize diverse argument shapes for `search_and_retrieve` using a tolerant parser
- Allow flexible MCP tool schema and add env toggles for strictness and logging
- Cover parsing scenarios with unit tests

## Testing
- `pytest orchestrator/test_normalize_args.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3cf93d7c88326bcaf2e180aa168da